### PR TITLE
Change piqi_src deps to git:// from https://

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {deps,
     [
-        {piqi_src, "", {git, "https://github.com/alavrik/piqi.git", {tag, "v0.5.7"}}}
+        {piqi_src, "", {git, "git://github.com/alavrik/piqi.git", {tag, "v0.5.7"}}}
     ]}.
 
 


### PR DESCRIPTION
Cloning from `https://` does not work on boxes which were built
last century and do not have "latest" SSL certificates. `git://` is the
standard protocol to download git dependencies, and it works everywhere.
