### PR TITLE
Fix normalize erlang names

### DIFF
--- a/src/piqic_erlang.erl
+++ b/src/piqic_erlang.erl
@@ -173,21 +173,12 @@ piqic_erlang(CallbackMod, Args) ->
     % capture the original Cwd so that we could restore it later
     Cwd = get_cwd(Odir),
     try
-        % call "piqi compile"
-        NormalizeNamesOpt =
-            case NormalizeNames of
-                true ->
-                    " --normalize-names";
-                false ->
-                    ""
-            end,
         PiqiCompile = lists:concat([
             find_piqi_executable(), " compile",
             " --self-spec ", SelfSpec,
             " -o ", CompiledPiqi,
             " -t pb",
             " -e erlang",  % automatically load .erlang.piqi extensions
-            NormalizeNamesOpt,
             " ", join_args(OtherArgs)
         ]),
         run_piqi_compile(PiqiCompile),
@@ -202,7 +193,7 @@ piqic_erlang(CallbackMod, Args) ->
 
         % finally, generate code for the last module in the list; the preceding
         % modules (if any) represent imported dependencies
-        Context = piqic:init_context(PiqiList),
+        Context = piqic:init_context(PiqiList, NormalizeNames),
         CallbackMod:generate(Context),
         ok
     catch

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,5 +9,6 @@ DIRS = \
 	erlang_piqi \
 	addressbook \
 	custom-types \
-	untyped-json-xml
+	untyped-json-xml\
+	normalize
 

--- a/tests/normalize/Makefile
+++ b/tests/normalize/Makefile
@@ -1,0 +1,33 @@
+PIQI_FILES = normalize.piqi nonormalize.piqi
+ESCRIPT = escript
+
+all:
+	ln -sf normalize.piqi nonormalize.piqi
+	$(MAKE) -f Makefile.normalize all;
+	$(MAKE) -f Makefile.nonormalize all;
+	$(ERLC) normalize_piqi_test.erl
+
+clean::
+	rm -f *.pb
+	rm -f *.piq
+	rm -f *typenames
+	rm -f *.beam
+	rm -f nonormalize.piqi
+
+test:
+# Get the protobuf blob from normalize.erl
+	$(ESCRIPT) normalize_piqi_test.beam get_pb
+
+# convert the protobuf to piq
+	$(PIQI) convert -f pb --type piqi normalize_piqi_from_erl.pb -o normalize_piqi_from_erl.piq
+	$(PIQI) convert -f pb --type piqi nonormalize_piqi_from_erl.pb -o nonormalize_piqi_from_erl.piq
+
+# convert piqi to piq
+	$(PIQI) compile normalize.piqi -o normalize.piq 
+	$(PIQI) compile nonormalize.piqi -o nonormalize.piq 
+
+# run tests
+	./normalize_test.sh
+
+include ../Makefile.piqi
+include ../Makefile.erlang

--- a/tests/normalize/Makefile.nonormalize
+++ b/tests/normalize/Makefile.nonormalize
@@ -1,0 +1,14 @@
+
+ERL_SOURCES = \
+	$(PIQI_ERL_FILES) \
+
+PIQI_FILES = nonormalize.piqi
+PIQIC_FLAGS = --normalize-names false
+
+PRE_TARGET = $(PIQI_ERLANG_FILES)
+
+all: ebin
+
+include ../Makefile.piqi
+include ../Makefile.erlang
+

--- a/tests/normalize/Makefile.normalize
+++ b/tests/normalize/Makefile.normalize
@@ -1,0 +1,14 @@
+
+ERL_SOURCES = \
+	$(PIQI_ERL_FILES) \
+
+PIQI_FILES = normalize.piqi
+PIQIC_FLAGS = --normalize-names true
+
+PRE_TARGET = $(PIQI_ERLANG_FILES)
+
+all: ebin
+
+include ../Makefile.piqi
+include ../Makefile.erlang
+

--- a/tests/normalize/nonormalize-piqi-typenames-test
+++ b/tests/normalize/nonormalize-piqi-typenames-test
@@ -1,0 +1,4 @@
+"nonormalize/string"
+"nonormalize/test-dashCap-CAPDash"
+"nonormalize/string"
+"nonormalize/test-dashCap-CAPDash"

--- a/tests/normalize/nonormalize_piqi.hrl-test
+++ b/tests/normalize/nonormalize_piqi.hrl-test
@@ -1,0 +1,15 @@
+-ifndef(__NONORMALIZE_PIQI_HRL__).
+-define(__NONORMALIZE_PIQI_HRL__, 1).
+
+
+-record(nonormalize_test_dashCap_CAPDash, {
+    fieldOne :: string() | binary(),
+    fieldTWO :: string() | binary(),
+    field_Three :: string() | binary(),
+    field_four :: string() | binary()
+}).
+
+-type nonormalize_test_dashCap_CAPDash() :: #nonormalize_test_dashCap_CAPDash{}.
+
+
+-endif.

--- a/tests/normalize/normalize-piqi-typenames-test
+++ b/tests/normalize/normalize-piqi-typenames-test
@@ -1,0 +1,4 @@
+"normalize/string"
+"normalize/test-dashCap-CAPDash"
+"normalize/string"
+"normalize/test-dashCap-CAPDash"

--- a/tests/normalize/normalize.piqi
+++ b/tests/normalize/normalize.piqi
@@ -1,0 +1,23 @@
+.record [
+	.name test-dashCap-CAPDash
+	.field [
+		.name fieldOne
+		.type string
+		.code 1
+	]
+	.field [
+		.name fieldTWO
+		.type string
+		.code 2
+	]
+	.field [
+		.name Field-Three
+		.type string
+		.code 3
+	]
+	.field [
+		.name field-four
+		.type string
+		.code 4
+	]
+]

--- a/tests/normalize/normalize_piqi.hrl-test
+++ b/tests/normalize/normalize_piqi.hrl-test
@@ -1,0 +1,15 @@
+-ifndef(__NORMALIZE_PIQI_HRL__).
+-define(__NORMALIZE_PIQI_HRL__, 1).
+
+
+-record(normalize_test_dash_cap_capdash, {
+    field_one :: string() | binary(),
+    field_two :: string() | binary(),
+    field_three :: string() | binary(),
+    field_four :: string() | binary()
+}).
+
+-type normalize_test_dash_cap_capdash() :: #normalize_test_dash_cap_capdash{}.
+
+
+-endif.

--- a/tests/normalize/normalize_piqi_test.erl
+++ b/tests/normalize/normalize_piqi_test.erl
@@ -1,0 +1,59 @@
+-module(normalize_piqi_test).
+-compile(export_all).
+-include("normalize_piqi.hrl").
+-include("nonormalize_piqi.hrl").
+get_pb() ->
+	get_pb(normalize_piqi),
+	get_pb(nonormalize_piqi).
+
+get_pb(Mod) ->
+	Pib = Mod:piqi(),
+	file:write_file(atom_to_list(Mod) ++ "_from_erl.pb", Pib).
+
+test_convert_normalize() ->
+	{ok, Bin} = piqi_tools:convert(normalize_piqi, <<"normalize/test-dashCap-CAPDash">>, 'json', 'pb', json()),
+	case normalize_piqi:parse_test_dash_cap_capdash(Bin) of 
+		#normalize_test_dash_cap_capdash{
+			field_one = <<"value1">>,
+			field_two = <<"value2">>, 
+			field_three = <<"value3">>, 
+			field_four = <<"value4">>
+		} -> ok;
+		Record -> io:format("test_convert_normalize failed: ~p~n", [Record]), error
+	end.
+
+test_convert_nonormalize() ->
+	{ok, Bin} = piqi_tools:convert(nonormalize_piqi, <<"nonormalize/test-dashCap-CAPDash">>, 'json', 'pb', json()),
+	case nonormalize_piqi:parse_test_dashCap_CAPDash(Bin) of 
+		#nonormalize_test_dashCap_CAPDash{
+			fieldOne = <<"value1">>,
+			fieldTWO = <<"value2">>, 
+			field_Three = <<"value3">>, 
+			field_four = <<"value4">>
+		} -> ok;
+		Record -> io:format("test_convert_nonormalize failed: ~p~n", [Record]), error
+	end.
+
+
+json() -> 
+	<<"{\"fieldOne\":\"value1\",\"fieldTWO\":\"value2\",\"Field_Three\":\"value3\",\"field_four\":\"value4\"}">>.
+%{\"fieldOne\":\"value1\",\"fieldTWO\":\"value2\",\"Field-Three\":\"value3\",\"field-four\":\"value4\"}
+%{"fieldOne":"value1","fieldTWO":"value2","Field-Three":"value3","field-four":"value4"}
+
+main([Fun|_Args]) ->	
+	true = code:add_pathz(filename:dirname(escript:script_name())++ "/../piqi/ebin"),
+	true = code:add_pathz(filename:dirname(escript:script_name())),
+	piqi:start(),
+	Res = case Fun of
+		"get_pb" -> get_pb();
+		"test_convert_normalize" -> test_convert_normalize();
+		"test_convert_nonormalize" -> test_convert_nonormalize();
+		_ -> io:format("Invalid input")
+	end,
+	case Res of
+		error -> halt(1);
+		_ -> ok
+	end;
+
+main(_) ->
+	io:format("Invalid input").

--- a/tests/normalize/normalize_test.sh
+++ b/tests/normalize/normalize_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get type names from .erl
+grep "<<\"normalize"  normalize_piqi.erl | sed "s/.*<<\(.*\)>>.*/\1/" > normalize-piqi-typenames
+grep "<<\"nonormalize"  nonormalize_piqi.erl | sed "s/.*<<\(.*\)>>.*/\1/" > nonormalize-piqi-typenames
+
+# These should be the same
+cmp normalize.piq normalize_piqi_from_erl.piq
+cmp nonormalize.piq nonormalize_piqi_from_erl.piq
+
+# Generated hrl should be equal
+cmp normalize_piqi.hrl normalize_piqi.hrl-test
+cmp nonormalize_piqi.hrl nonormalize_piqi.hrl-test
+
+# Check if typenames are equal
+cmp normalize-piqi-typenames normalize-piqi-typenames-test
+cmp nonormalize-piqi-typenames nonormalize-piqi-typenames-test
+
+# Check conversions
+escript normalize_piqi_test.beam test_convert_normalize
+escript normalize_piqi_test.beam test_convert_nonormalize


### PR DESCRIPTION
This pull requests moves the normalization of identifiers from piqi into piqi-erlang. Since the normalization should not happen in the transport, but only in the names of erlang records, types and functions. 
This fixes the issue where conversions would fail if type or field names contain camelcased names and normalization was turned on. Also fixes the problems with piqi rpc function names being normalized
