### PR TITLE
Migrate to new try/catch syntax to get stack trace directly

### DIFF
--- a/src/piqi_rpc_runtime.erl
+++ b/src/piqi_rpc_runtime.erl
@@ -84,17 +84,11 @@ decode_input(RpcMod, Decoder, TypeName, InputFormat, InputData, Options) ->
     Decoder(BinInput).
 
 
--ifdef(OTP_RELEASE).  % >= R21?
--compile({nowarn_deprecated_function, {erlang,get_stacktrace,0}}).
--endif.
-
-
 encode_common(RpcMod, Encoder, TypeName, OutputFormat, Output, Options) ->
     IolistOutput =
         try Encoder(Output)
         catch
-            Class:Reason ->
-                Stacktrace = erlang:get_stacktrace(),
+            Class:Reason:Stacktrace ->
                 OutputStr = lists:flatten(format_term(Output)),
                 Error = io_lib:format(
                     "error encoding output:~n"

--- a/src/piqic_erlang_rpc.erl
+++ b/src/piqic_erlang_rpc.erl
@@ -31,9 +31,6 @@ gen_piqi(Context) ->
         "get_piqi(OutputFormat, Options) ->\n",
         "    piqi_rpc_runtime:get_piqi(piqi(), OutputFormat, Options).\n",
         "\n\n",
-        "-ifdef(OTP_RELEASE).  % >= R21?\n"
-        "-compile({nowarn_deprecated_function, {erlang,get_stacktrace,0}}).\n"
-        "-endif.\n"
         "\n\n",
         "rpc(Mod, Name, InputData, _InputFormat, _OutputFormat, Options) ->\n",
         "    try\n",
@@ -43,7 +40,7 @@ gen_piqi(Context) ->
         "            piqi_rpc_runtime:handle_unknown_function()\n"
         "    end\n",
         "    catch\n",
-        "        Class:Reason -> Stacktrace = erlang:get_stacktrace(), piqi_rpc_runtime:handle_runtime_exception(Class, Reason, Stacktrace, Options)\n",
+        "        Class:Reason:Stacktrace -> piqi_rpc_runtime:handle_runtime_exception(Class, Reason, Stacktrace, Options)\n",
         "    end.\n"
     ].
 


### PR DESCRIPTION
The new syntax was added many years ago (see https://github.com/erlang/otp/pull/1634), and the old syntax was also deprecated 7 years ago (see https://github.com/erlang/otp/pull/1783).

This makes piqi incompatible with older OTP versions (pre-OTP21), but I am going to try taking an opinionated stance and see whether this is acceptable :)

The alternative would be to use macros to check the OTP version and select the code appropriate for the OTP version in use, but that would mean more boilerplate.